### PR TITLE
Migrate to flake8 3.x

### DIFF
--- a/unicode_string_literal.py
+++ b/unicode_string_literal.py
@@ -21,8 +21,8 @@ class UnicodeStringLiteral(object):
     def add_options(cls, parser):
         parser.add_option('--utter-unicode-string-literals',
                           action='store_true',
+                          parse_from_config=True,
                           help="Expect all literal strings to be unicode")
-        parser.config_options.append('utter-unicode-string-literals')
 
     @classmethod
     def parse_options(cls, options):


### PR DESCRIPTION
Since flake8 3.0, registering options is handled differently.

See http://flake8.pycqa.org/en/latest/plugin-development/cross-compatibility.html

Fix #1
